### PR TITLE
feat: 支持简单的后缀名分类子目录支持

### DIFF
--- a/src/core/download_helper.cc
+++ b/src/core/download_helper.cc
@@ -137,7 +137,7 @@ createRequestGroup(const std::shared_ptr<Option>& optionTemplate,
   auto dctx = std::make_shared<DownloadContext>(
       option->getAsInt(PREF_PIECE_LENGTH), 0,
       useOutOption && !option->blank(PREF_OUT)
-          ? util::applyDir(option->get(PREF_DIR), option->get(PREF_OUT))
+          ? util::generateRequestGroupPath(option, false)
           : A2STR::NIL);
   dctx->getFirstFileEntry()->setUris(uris);
   dctx->getFirstFileEntry()->setMaxConnectionPerServer(

--- a/src/core/download_helper.cc
+++ b/src/core/download_helper.cc
@@ -137,7 +137,7 @@ createRequestGroup(const std::shared_ptr<Option>& optionTemplate,
   auto dctx = std::make_shared<DownloadContext>(
       option->getAsInt(PREF_PIECE_LENGTH), 0,
       useOutOption && !option->blank(PREF_OUT)
-          ? util::generateRequestGroupPath(option, false)
+          ? util::applyDir(option->get(PREF_DIR), option->get(PREF_OUT))
           : A2STR::NIL);
   dctx->getFirstFileEntry()->setUris(uris);
   dctx->getFirstFileEntry()->setMaxConnectionPerServer(

--- a/src/core/usage_text.h
+++ b/src/core/usage_text.h
@@ -1134,6 +1134,6 @@
   _(" --category-dir=CATEGORY_DIR\n"\
     "                              Set the directory to save files based on category.\n" \
     "                              expmple download auto sub dir\n"\
-    "                              aria2c --category-dir=\"archive:.zip,.rar\" http://host/file.rar\n")
+    "                              aria2c --category-dir=\"archive:.zip,.rar;text:.txt,.md\" http://host/file.rar\n")
 
 // clang-format on

--- a/src/core/usage_text.h
+++ b/src/core/usage_text.h
@@ -1130,4 +1130,10 @@
     "                              successful, then skip downloading metadata from\n" \
     "                              DHT.")
 
+#define TEXT_CATEGORY_DIR \
+  _(" --category-dir=CATEGORY_DIR\n"\
+    "                              Set the directory to save files based on category.\n" \
+    "                              expmple download auto sub dir\n"\
+    "                              aria2c --category-dir=\"archive:.zip,.rar\" http://host/file.rar\n")
+
 // clang-format on

--- a/src/network/FtpNegotiationCommand.cc
+++ b/src/network/FtpNegotiationCommand.cc
@@ -393,9 +393,7 @@ bool FtpNegotiationCommand::onFileSizeDetermined(int64_t totalLength)
         util::percentDecode(std::begin(getRequest()->getFile()),
                             std::end(getRequest()->getFile())));
 
-    getFileEntry()->setPath(
-        util::applyDir(getOption()->get(PREF_DIR), suffixPath));
-    getFileEntry()->setSuffixPath(suffixPath);
+    util::commonFileEntrySetPath(getFileEntry(), getOption(), suffixPath, true);
   }
   getRequestGroup()->preDownloadProcessing();
   if (totalLength == 0) {

--- a/src/network/HttpResponseCommand.cc
+++ b/src/network/HttpResponseCommand.cc
@@ -193,8 +193,7 @@ bool HttpResponseCommand::executeInternal()
           getRequest()->getFile().empty()
               ? Request::DEFAULT_FILE
               : util::percentDecode(std::begin(file), std::end(file)));
-      fe->setPath(util::applyDir(getOption()->get(PREF_DIR), suffixPath));
-      fe->setSuffixPath(suffixPath);
+      util::commonFileEntrySetPath(fe, getOption(), suffixPath, true);
     }
 
     A2_LOG_NOTICE(fmt(MSG_DOWNLOAD_ALREADY_COMPLETED,
@@ -263,8 +262,7 @@ bool HttpResponseCommand::executeInternal()
     if (fe->getPath().empty()) {
       auto suffixPath = util::createSafePath(httpResponse->determineFilename(
           getOption()->getAsBool(PREF_CONTENT_DISPOSITION_DEFAULT_UTF8)));
-      fe->setPath(util::applyDir(getOption()->get(PREF_DIR), suffixPath));
-      fe->setSuffixPath(suffixPath);
+      util::commonFileEntrySetPath(fe, getOption(), suffixPath, true);
     }
     fe->setContentType(httpResponse->getContentType());
     grp->preDownloadProcessing();

--- a/src/parser/OptionHandlerFactory.cc
+++ b/src/parser/OptionHandlerFactory.cc
@@ -1983,6 +1983,17 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     handlers.push_back(op);
   }
 #endif // ENABLE_METALINK
+  {
+
+    OptionHandler* op(new CumulativeOptionHandler(PREF_CATEGORY_DIR, TEXT_CATEGORY_DIR,
+                                                  NO_DEFAULT_VALUE, ";"));
+    op->addTag(TAG_BASIC);
+    op->setInitialOption(true);
+    op->setCumulative(true);
+    op->setChangeGlobalOption(true);
+    op->setChangeOptionForReserved(true);
+    handlers.push_back(op);
+  }
   // Version Option
   {
     OptionHandler* op(new DefaultOptionHandler(PREF_VERSION, TEXT_VERSION,

--- a/src/parser/OptionHandlerFactory.cc
+++ b/src/parser/OptionHandlerFactory.cc
@@ -1985,8 +1985,8 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
 #endif // ENABLE_METALINK
   {
 
-    OptionHandler* op(new CumulativeOptionHandler(PREF_CATEGORY_DIR, TEXT_CATEGORY_DIR,
-                                                  NO_DEFAULT_VALUE, ";"));
+    OptionHandler* op(new CumulativeOptionHandler(
+        PREF_CATEGORY_DIR, TEXT_CATEGORY_DIR, NO_DEFAULT_VALUE, ";"));
     op->addTag(TAG_BASIC);
     op->setCumulative(true);
     op->setChangeGlobalOption(true);

--- a/src/parser/OptionHandlerFactory.cc
+++ b/src/parser/OptionHandlerFactory.cc
@@ -1988,7 +1988,6 @@ std::vector<OptionHandler*> OptionHandlerFactory::createOptionHandlers()
     OptionHandler* op(new CumulativeOptionHandler(PREF_CATEGORY_DIR, TEXT_CATEGORY_DIR,
                                                   NO_DEFAULT_VALUE, ";"));
     op->addTag(TAG_BASIC);
-    op->setInitialOption(true);
     op->setCumulative(true);
     op->setChangeGlobalOption(true);
     op->setChangeOptionForReserved(true);

--- a/src/protocol/sftp/SftpNegotiationCommand.cc
+++ b/src/protocol/sftp/SftpNegotiationCommand.cc
@@ -202,9 +202,7 @@ void SftpNegotiationCommand::onFileSizeDetermined(int64_t totalLength)
         util::percentDecode(std::begin(getRequest()->getFile()),
                             std::end(getRequest()->getFile())));
 
-    getFileEntry()->setPath(
-        util::applyDir(getOption()->get(PREF_DIR), suffixPath));
-    getFileEntry()->setSuffixPath(suffixPath);
+    util::commonFileEntrySetPath(getFileEntry(), getOption(), suffixPath, true);
   }
   getRequestGroup()->preDownloadProcessing();
 

--- a/src/util/prefs.cc
+++ b/src/util/prefs.cc
@@ -592,4 +592,6 @@ PrefPtr PREF_METALINK_ENABLE_UNIQUE_PROTOCOL =
     makePref("metalink-enable-unique-protocol");
 PrefPtr PREF_METALINK_BASE_URI = makePref("metalink-base-uri");
 
+PrefPtr PREF_CATEGORY_DIR = makePref("category-dir");
+
 } // namespace aria2

--- a/src/util/prefs.h
+++ b/src/util/prefs.h
@@ -542,6 +542,8 @@ extern PrefPtr PREF_METALINK_ENABLE_UNIQUE_PROTOCOL;
 // values: a string
 extern PrefPtr PREF_METALINK_BASE_URI;
 
+extern PrefPtr PREF_CATEGORY_DIR;
+
 } // namespace aria2
 
 #endif // D_PREFS_H

--- a/src/util/util.cc
+++ b/src/util/util.cc
@@ -2634,6 +2634,11 @@ std::string mathCatrgoryDir(const std::string& catrgoryDirOptions,
     sStart = iStart;
     std::string catrgoryDir = catrgoryDirOptions.substr(cStart, cEnd - cStart);
     while (sStart < iEnd) {
+      // skip ,,
+      if (catrgoryDirOptions[sStart] == ',') {
+        sStart++;
+        continue;
+      }
       sEnd = catrgoryDirOptions.find(',', sStart);
       if (sEnd == std::string::npos)
         sEnd = iEnd;

--- a/src/util/util.cc
+++ b/src/util/util.cc
@@ -2095,15 +2095,17 @@ bool saveAs(const std::string& filename, const std::string& data,
   return File(tempFilename).renameTo(filename);
 }
 
-#  define isWindowsDeviceRoot(b)                                               \
-    ((b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z'))
+#define isWindowsDeviceRoot(b)                                                 \
+  ((b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z'))
 bool isAbsolute(const std::string& path)
 {
   if (path.empty()) {
     return false;
   }
-  if (path[0] == '/' || path[0] == '\\') return true;
-  return path.size() > 2 && isWindowsDeviceRoot(path[0]) && path[1] == ':' && (path[2] == '/' || path[2] == '\\');
+  if (path[0] == '/' || path[0] == '\\')
+    return true;
+  return path.size() > 2 && isWindowsDeviceRoot(path[0]) && path[1] == ':' &&
+         (path[2] == '/' || path[2] == '\\');
 }
 
 std::string applyDir(const std::string& dir, const std::string& relPath)
@@ -2604,10 +2606,9 @@ bool gainPrivilege(LPCTSTR privName)
 }
 #endif // _WIN32
 
-std::string mathCatrgoryDir(
-  const std::string& catrgoryDirOptions,
-  const std::string& suffixPath
-) {
+std::string mathCatrgoryDir(const std::string& catrgoryDirOptions,
+                            const std::string& suffixPath)
+{
   size_t start = 0;
   size_t end = catrgoryDirOptions.size();
   size_t cStart = 0;
@@ -2616,8 +2617,7 @@ std::string mathCatrgoryDir(
   size_t iEnd = 0;
   size_t sStart = 0;
   size_t sEnd = 0;
-  while (start < end)
-  {
+  while (start < end) {
     // skip ;;
     if (catrgoryDirOptions[start] == ';') {
       start++;
@@ -2625,18 +2625,21 @@ std::string mathCatrgoryDir(
     }
     cStart = start;
     cEnd = catrgoryDirOptions.find(':', cStart);
-    if (cEnd == std::string::npos) break;
+    if (cEnd == std::string::npos)
+      break;
     iStart = cEnd + 1;
     iEnd = catrgoryDirOptions.find(';', iStart);
-    if (iEnd == std::string::npos) iEnd = end;
+    if (iEnd == std::string::npos)
+      iEnd = end;
     sStart = iStart;
     std::string catrgoryDir = catrgoryDirOptions.substr(cStart, cEnd - cStart);
-    while (sStart < iEnd)
-    {
+    while (sStart < iEnd) {
       sEnd = catrgoryDirOptions.find(',', sStart);
-      if (sEnd == std::string::npos) sEnd = iEnd;
+      if (sEnd == std::string::npos)
+        sEnd = iEnd;
       if (catrgoryDirOptions[sStart] == '.') {
-        std::string catrgorySuffixPath = catrgoryDirOptions.substr(sStart, sEnd - sStart);
+        std::string catrgorySuffixPath =
+            catrgoryDirOptions.substr(sStart, sEnd - sStart);
         if (util::endsWith(suffixPath, catrgorySuffixPath)) {
           return catrgoryDir;
         }
@@ -2648,15 +2651,16 @@ std::string mathCatrgoryDir(
   return A2STR::NIL;
 }
 
-std::string generateRequestGroupPath(
-  const std::shared_ptr<Option>& opt,
-  const bool isRemoteSuffixPath
-) {
+std::string generateRequestGroupPath(const std::shared_ptr<Option>& opt,
+                                     const bool isRemoteSuffixPath)
+{
   std::string prefixDir = opt->get(PREF_DIR);
   std::string suffixPath = opt->get(PREF_OUT);
   auto suffixPathIsAbsolute = util::isAbsolute(suffixPath);
-  if (!suffixPath.empty() && !opt->blank(PREF_CATEGORY_DIR) && !suffixPathIsAbsolute) {
-    std::string catrgoryDir = mathCatrgoryDir(opt->get(PREF_CATEGORY_DIR), suffixPath);
+  if (!suffixPath.empty() && !opt->blank(PREF_CATEGORY_DIR) &&
+      !suffixPathIsAbsolute) {
+    std::string catrgoryDir =
+        mathCatrgoryDir(opt->get(PREF_CATEGORY_DIR), suffixPath);
     if (!catrgoryDir.empty() && !util::startsWith(suffixPath, catrgoryDir)) {
       std::string catrgorySuffixPath = util::applyDir(catrgoryDir, suffixPath);
       return util::applyDir(prefixDir, catrgorySuffixPath);
@@ -2669,17 +2673,20 @@ std::string generateRequestGroupPath(
   return util::applyDir(prefixDir, suffixPath);
 }
 
-void commonFileEntrySetPath(
-  const std::shared_ptr<FileEntry>& fileEntry,
-  const std::shared_ptr<Option>& opt,
-  const std::string& suffixPath,
-  const bool isRemoteSuffixPath) {
+void commonFileEntrySetPath(const std::shared_ptr<FileEntry>& fileEntry,
+                            const std::shared_ptr<Option>& opt,
+                            const std::string& suffixPath,
+                            const bool isRemoteSuffixPath)
+{
   auto suffixPathIsAbsolute = util::isAbsolute(suffixPath);
-  if (!suffixPath.empty() && !opt->blank(PREF_CATEGORY_DIR) && !suffixPathIsAbsolute) {
-    std::string catrgoryDir = mathCatrgoryDir(opt->get(PREF_CATEGORY_DIR), suffixPath);
+  if (!suffixPath.empty() && !opt->blank(PREF_CATEGORY_DIR) &&
+      !suffixPathIsAbsolute) {
+    std::string catrgoryDir =
+        mathCatrgoryDir(opt->get(PREF_CATEGORY_DIR), suffixPath);
     if (!catrgoryDir.empty() && !util::startsWith(suffixPath, catrgoryDir)) {
       std::string catrgorySuffixPath = util::applyDir(catrgoryDir, suffixPath);
-      fileEntry->setPath(util::applyDir(opt->get(PREF_DIR), catrgorySuffixPath));
+      fileEntry->setPath(
+          util::applyDir(opt->get(PREF_DIR), catrgorySuffixPath));
       fileEntry->setSuffixPath(catrgorySuffixPath);
       return;
     }

--- a/src/util/util.cc
+++ b/src/util/util.cc
@@ -2095,11 +2095,22 @@ bool saveAs(const std::string& filename, const std::string& data,
   return File(tempFilename).renameTo(filename);
 }
 
+#  define isWindowsDeviceRoot(b)                                               \
+    ((b >= 'A' && b <= 'Z') || (b >= 'a' && b <= 'z'))
+bool isAbsolute(const std::string& path)
+{
+  if (path.empty()) {
+    return false;
+  }
+  if (path[0] == '/') return true;
+  return path.size() > 2 && isWindowsDeviceRoot(path[0]) && path[1] == ':' && (path[2] == '/' || path[2] == '\\');
+}
+
 std::string applyDir(const std::string& dir, const std::string& relPath)
 {
   std::string s;
   if (dir.empty()) {
-    s = "./";
+    s = isAbsolute(relPath) ? A2STR::NIL : "./";
     s += relPath;
   }
   else {

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -730,7 +730,10 @@ bool saveAs(const std::string& filename, const std::string& data,
 // dir = "/dir", relPath = "foo" => "/dir/foo"
 // dir = "",     relPath = "foo" => "./foo"
 // dir = "/",    relPath = "foo" => "/foo"
+// dir = "", relPath = "/foo" => "/foo"
 std::string applyDir(const std::string& dir, const std::string& relPath);
+
+bool isAbsolute(const std::string& path);
 
 // In HTTP/FTP, file name is file component in URI. In HTTP, filename
 // may be a value of Content-Disposition header.  They are likely

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -884,6 +884,15 @@ void make_fd_cloexec(int fd);
 #ifdef _WIN32
 bool gainPrivilege(LPCTSTR privName);
 #endif // _WIN32
+std::string mathCatrgoryDir(
+  const std::string& catrgoryDirOptions,
+  const std::string& suffixPath);
+std::string generateRequestGroupPath(const std::shared_ptr<Option>& opt, const bool isRemoteSuffixPath = false);
+void commonFileEntrySetPath(
+  const std::shared_ptr<FileEntry>& fileEntry,
+  const std::shared_ptr<Option>& opt,
+  const std::string& suffixPath,
+  const bool isRemoteSuffixPath = false);
 
 } // namespace util
 

--- a/src/util/util.h
+++ b/src/util/util.h
@@ -884,15 +884,14 @@ void make_fd_cloexec(int fd);
 #ifdef _WIN32
 bool gainPrivilege(LPCTSTR privName);
 #endif // _WIN32
-std::string mathCatrgoryDir(
-  const std::string& catrgoryDirOptions,
-  const std::string& suffixPath);
-std::string generateRequestGroupPath(const std::shared_ptr<Option>& opt, const bool isRemoteSuffixPath = false);
-void commonFileEntrySetPath(
-  const std::shared_ptr<FileEntry>& fileEntry,
-  const std::shared_ptr<Option>& opt,
-  const std::string& suffixPath,
-  const bool isRemoteSuffixPath = false);
+std::string mathCatrgoryDir(const std::string& catrgoryDirOptions,
+                            const std::string& suffixPath);
+std::string generateRequestGroupPath(const std::shared_ptr<Option>& opt,
+                                     const bool isRemoteSuffixPath = false);
+void commonFileEntrySetPath(const std::shared_ptr<FileEntry>& fileEntry,
+                            const std::shared_ptr<Option>& opt,
+                            const std::string& suffixPath,
+                            const bool isRemoteSuffixPath = false);
 
 } // namespace util
 

--- a/test/OptionParserTest.cc
+++ b/test/OptionParserTest.cc
@@ -1,4 +1,5 @@
 #include "OptionParser.h"
+#include "OptionHandlerFactory.h"
 
 #include <cstring>
 #include <sstream>
@@ -28,6 +29,10 @@ class OptionParserTest : public CppUnit::TestFixture {
   CPPUNIT_TEST(testParseArg);
   CPPUNIT_TEST(testParse);
   CPPUNIT_TEST(testParseKeyVals);
+  CPPUNIT_TEST(testParseCatrgoryDir1);
+  CPPUNIT_TEST(testParseCatrgoryDir2);
+  CPPUNIT_TEST(testParseCatrgoryDir3);
+  CPPUNIT_TEST(testParseCatrgoryDir4);
   CPPUNIT_TEST_SUITE_END();
 
 private:
@@ -76,6 +81,10 @@ public:
   void testParseArg();
   void testParse();
   void testParseKeyVals();
+  void testParseCatrgoryDir1();
+  void testParseCatrgoryDir2();
+  void testParseCatrgoryDir3();
+  void testParseCatrgoryDir4();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(OptionParserTest);
@@ -208,6 +217,50 @@ void OptionParserTest::testParseKeyVals()
   oparser_->parse(option, kv);
   CPPUNIT_ASSERT_EQUAL(std::string("Hello"), option.get(PREF_TIMEOUT));
   CPPUNIT_ASSERT_EQUAL(std::string("World"), option.get(PREF_DIR));
+}
+
+void OptionParserTest::testParseCatrgoryDir1()
+{
+  Option option;
+  oparser_->setOptionHandlers(
+        OptionHandlerFactory::createOptionHandlers());
+  std::istringstream in("category-dir=archive:.zip,.rar");
+  oparser_->parse(option, in);
+  CPPUNIT_ASSERT_EQUAL(std::string("archive:.zip,.rar;"), option.get(PREF_CATEGORY_DIR));
+}
+
+void OptionParserTest::testParseCatrgoryDir2()
+{
+  Option option;
+  oparser_->setOptionHandlers(
+        OptionHandlerFactory::createOptionHandlers());
+  std::istringstream in("category-dir=archive:.zip,.rar;text:.txt");
+  oparser_->parse(option, in);
+  CPPUNIT_ASSERT_EQUAL(std::string("archive:.zip,.rar;text:.txt;"), option.get(PREF_CATEGORY_DIR));
+}
+
+
+void OptionParserTest::testParseCatrgoryDir3()
+{
+  Option option;
+  oparser_->setOptionHandlers(
+        OptionHandlerFactory::createOptionHandlers());
+  std::istringstream in("category-dir=archive:.zip,.rar\n"
+  "category-dir=text:.txt");
+  oparser_->parse(option, in);
+  CPPUNIT_ASSERT_EQUAL(std::string("archive:.zip,.rar;text:.txt;"), option.get(PREF_CATEGORY_DIR));
+}
+
+
+void OptionParserTest::testParseCatrgoryDir4()
+{
+  Option option;
+  oparser_->setOptionHandlers(
+        OptionHandlerFactory::createOptionHandlers());
+  std::istringstream in("category-dir=archive:.zip,.rar;\n"
+  "category-dir=text:.txt;");
+  oparser_->parse(option, in);
+  CPPUNIT_ASSERT_EQUAL(std::string("archive:.zip,.rar;;text:.txt;;"), option.get(PREF_CATEGORY_DIR));
 }
 
 } // namespace aria2

--- a/test/UtilTest2.cc
+++ b/test/UtilTest2.cc
@@ -1015,7 +1015,7 @@ void UtilTest2::testMathCatrgoryDir()
   CPPUNIT_ASSERT_EQUAL(std::string(""), util::mathCatrgoryDir(catrgoryDir1, "a.zipx"));
   CPPUNIT_ASSERT_EQUAL(std::string("text"), util::mathCatrgoryDir(catrgoryDir1, "a.txt"));
 
-  const std::string catrgoryDir2 = "archive:.zip,.rar;;text:.txt;;";
+  const std::string catrgoryDir2 = "archive:.zip,,.rar,;;text:.txt;;";
   CPPUNIT_ASSERT_EQUAL(std::string("archive"), util::mathCatrgoryDir(catrgoryDir2, "a.zip"));
   CPPUNIT_ASSERT_EQUAL(std::string("archive"), util::mathCatrgoryDir(catrgoryDir2, "a.rar"));
   CPPUNIT_ASSERT_EQUAL(std::string(""), util::mathCatrgoryDir(catrgoryDir2, "a.zipx"));

--- a/test/UtilTest2.cc
+++ b/test/UtilTest2.cc
@@ -786,6 +786,11 @@ void UtilTest2::testApplyDir()
   CPPUNIT_ASSERT_EQUAL(std::string("/pred"), util::applyDir("/", "pred"));
   CPPUNIT_ASSERT_EQUAL(std::string("./pred"), util::applyDir(".", "pred"));
   CPPUNIT_ASSERT_EQUAL(std::string("/dl/pred"), util::applyDir("/dl", "pred"));
+  CPPUNIT_ASSERT_EQUAL(std::string("/pred"), util::applyDir("", "/pred"));
+  CPPUNIT_ASSERT_EQUAL(std::string("C:/pred"), util::applyDir("", "C:/pred"));
+#ifdef _WIN32
+  CPPUNIT_ASSERT_EQUAL(std::string("C:/pred"), util::applyDir("", "C:\\pred"));
+#endif // _WIN32
 }
 
 void UtilTest2::testFixTaintedBasename()

--- a/test/UtilTest2.cc
+++ b/test/UtilTest2.cc
@@ -68,6 +68,7 @@ class UtilTest2 : public CppUnit::TestFixture {
   CPPUNIT_TEST(testSecfmt);
   CPPUNIT_TEST(testTlsHostnameMatch);
   CPPUNIT_TEST(testParseDoubleNoThrow);
+  CPPUNIT_TEST(testMathCatrgoryDir);
   CPPUNIT_TEST_SUITE_END();
 
 private:
@@ -118,6 +119,7 @@ public:
   void testSecfmt();
   void testTlsHostnameMatch();
   void testParseDoubleNoThrow();
+  void testMathCatrgoryDir();
 };
 
 CPPUNIT_TEST_SUITE_REGISTRATION(UtilTest2);
@@ -1003,6 +1005,21 @@ void UtilTest2::testParseDoubleNoThrow()
 
   CPPUNIT_ASSERT(!util::parseDoubleNoThrow(n, ""));
   CPPUNIT_ASSERT(!util::parseDoubleNoThrow(n, "123x"));
+}
+
+void UtilTest2::testMathCatrgoryDir()
+{
+  const std::string catrgoryDir1 = "archive:.zip,.rar;text:.txt;";
+  CPPUNIT_ASSERT_EQUAL(std::string("archive"), util::mathCatrgoryDir(catrgoryDir1, "a.zip"));
+  CPPUNIT_ASSERT_EQUAL(std::string("archive"), util::mathCatrgoryDir(catrgoryDir1, "a.rar"));
+  CPPUNIT_ASSERT_EQUAL(std::string(""), util::mathCatrgoryDir(catrgoryDir1, "a.zipx"));
+  CPPUNIT_ASSERT_EQUAL(std::string("text"), util::mathCatrgoryDir(catrgoryDir1, "a.txt"));
+
+  const std::string catrgoryDir2 = "archive:.zip,.rar;;text:.txt;;";
+  CPPUNIT_ASSERT_EQUAL(std::string("archive"), util::mathCatrgoryDir(catrgoryDir2, "a.zip"));
+  CPPUNIT_ASSERT_EQUAL(std::string("archive"), util::mathCatrgoryDir(catrgoryDir2, "a.rar"));
+  CPPUNIT_ASSERT_EQUAL(std::string(""), util::mathCatrgoryDir(catrgoryDir2, "a.zipx"));
+  CPPUNIT_ASSERT_EQUAL(std::string("text"), util::mathCatrgoryDir(catrgoryDir2, "a.txt"));
 }
 
 } // namespace aria2

--- a/xmake.lua
+++ b/xmake.lua
@@ -351,6 +351,7 @@ if get_config("unit") then
 target("test")
     set_default(false)
     add_files("test/AllTest.cc", "test/TestUtil.cc")
+    -- add_files("test/UtilTest2.cc")
     add_files("test/*.cc|AllTest.cc|TestUtil.cc|CookieBoxTest.cc")
     add_deps("aria2")
     add_includedirs(


### PR DESCRIPTION
命令行示例
by https://github.com/jc3213/download_with_aria2/issues/104
``` sh
> aria2c --category-dir='压缩包:.zip,.rar;网页:.html,.htm' https://xxx
```
**配置文件示例:**
```
category-dir=压缩包:.zip,.rar
category-dir=网页:.html,.htm
```
**一些注意事项:**

- 以 `;` 为每个目录的分隔符
- 以 `:` 结束目录名开始文件名的后缀匹配
- 以 `,` 为每个文件名的后缀匹配必须以 `.` 开头
- 只对自动生成的路径添加（http,ftp,sftp），手动使用 `-o` 和下载列表里设置命名的情况是不会生效的