### PR TITLE
fix: 多线程访问 RequestGroupMan 导致的数据异常

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -15,35 +15,35 @@ jobs:
         uses: xmake-io/github-action-setup-xmake@v1
         with:
           xmake-version: latest
-      - name: Download llvm-mingw
-        uses: robinraju/release-downloader@main
-        with:
-          repository: "mstorsjo/llvm-mingw"
-          latest: true
-          extract: false
-          fileName: "llvm-mingw-*-ucrt-x86_64.zip"
-      - name: Install llvm-mingw
-        run: |
-          unzip llvm-mingw-*-ucrt-x86_64.zip | Out-Null && rm llvm-mingw-*-ucrt-x86_64.zip
-          mv llvm-mingw-* llvm-mingw
-      - name: build x64
-        env:
-          VERSION: ${{ github.ref_name }}
-        run: |
-          $env:PATH = "$(Get-Location)\llvm-mingw\bin;$env:PATH"
-          xmake f -p mingw -a x86_64 -c -y --use_quictls=n && xmake pack aria2
-      # - name: build arm64
-      #   env:
-      #     VERSION: ${{ github.ref_name }}
-      #   run: xmake f -a arm64 -c -y && xmake pack aria2
-      # - name: build x86
-      #   env:
-      #     VERSION: ${{ github.ref_name }}
-      #   run: xmake f -a x86 -c -y && xmake pack aria2
+      # - name: Download llvm-mingw
+      #   uses: robinraju/release-downloader@main
+      #   with:
+      #     repository: "mstorsjo/llvm-mingw"
+      #     latest: true
+      #     extract: false
+      #     fileName: "llvm-mingw-*-ucrt-x86_64.zip"
+      # - name: Install llvm-mingw
+      #   run: |
+      #     unzip llvm-mingw-*-ucrt-x86_64.zip | Out-Null && rm llvm-mingw-*-ucrt-x86_64.zip
+      #     mv llvm-mingw-* llvm-mingw
       # - name: build x64
       #   env:
       #     VERSION: ${{ github.ref_name }}
-      #   run: xmake f -a x64 -c -y && xmake pack aria2
+      #   run: |
+      #     $env:PATH = "$(Get-Location)\llvm-mingw\bin;$env:PATH"
+      #     xmake f -p mingw -a x86_64 -c -y --use_quictls=n && xmake pack aria2
+      - name: build arm64
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: xmake f -a arm64 -c -y && xmake pack aria2
+      - name: build x86
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: xmake f -a x86 -c -y && xmake pack aria2
+      - name: build x64
+        env:
+          VERSION: ${{ github.ref_name }}
+        run: xmake f -a x64 -c -y && xmake pack aria2
       - name: cp
         run: New-Item -ItemType Directory -Path dist && cp build/xpack/aria2/*.zip dist/
       - uses: actions/upload-artifact@v4

--- a/.gitignore
+++ b/.gitignore
@@ -50,3 +50,4 @@ build
 dist
 !config.h.in
 .DS_Store
+sym

--- a/package.lua
+++ b/package.lua
@@ -22,3 +22,8 @@ end
 if is_plat("windows", "mingw") then
     add_requires("gettext-tools", {optional = true})
 end
+
+
+if get_config("with_breakpad") then
+    add_requires("breakpad")
+end

--- a/src/core/AutoSaveCommand.cc
+++ b/src/core/AutoSaveCommand.cc
@@ -40,7 +40,7 @@ namespace aria2 {
 
 AutoSaveCommand::AutoSaveCommand(cuid_t cuid, DownloadEngine* e,
                                  std::chrono::seconds interval)
-    : TimeBasedAsyncCommand(cuid, e, std::move(interval), true)
+    : TimeBasedCommand(cuid, e, std::move(interval), true)
 {
 }
 

--- a/src/core/AutoSaveCommand.h
+++ b/src/core/AutoSaveCommand.h
@@ -35,11 +35,11 @@
 #ifndef D_AUTO_SAVE_COMMAND_H
 #define D_AUTO_SAVE_COMMAND_H
 
-#include "TimeBasedAsyncCommand.h"
+#include "TimeBasedCommand.h"
 
 namespace aria2 {
 
-class AutoSaveCommand : public TimeBasedAsyncCommand {
+class AutoSaveCommand : public TimeBasedCommand {
   COMMAND_CLASSNAME(AutoSaveCommand)
 public:
   AutoSaveCommand(cuid_t cuid, DownloadEngine* e,

--- a/src/main.cc
+++ b/src/main.cc
@@ -49,6 +49,15 @@
 #include "console.h"
 #include "LogFactory.h"
 #include "util.h"
+#include "File.h"
+#include <iostream>
+
+#ifdef _WIN32
+#include <client/windows/handler/exception_handler.h>
+#elif defined(__APPLE__)
+#include <client/mac/handler/exception_handler.h>
+#endif // _WIN32
+
 
 namespace aria2 {
 
@@ -83,8 +92,64 @@ error_code::Value main(int argc, char** argv)
 
 } // namespace aria2
 
+#ifdef ENABLE_BREAKPAD
+#ifdef _WIN32
+static bool callback(const wchar_t* dump_path,
+  const wchar_t* minidump_id,
+  void* context,
+  EXCEPTION_POINTERS* exinfo,
+  MDRawAssertionInfo* assertion,
+  bool succeeded) {
+  std::wcerr << L"Crash dump:" << dump_path << L"\\" << minidump_id << std::endl;
+  return succeeded;
+}
+
+static std::unique_ptr<google_breakpad::ExceptionHandler> initExceptionHandler() {
+  std::string localeDir = aria2::util::applyDir(aria2::util::getProgramLocation(), "dumps");
+  std::replace(localeDir.begin(), localeDir.end(), '/', '\\');
+  aria2::File dir(localeDir);
+  if (!dir.exists()) {
+    a2mkdir(aria2::utf8ToWChar(localeDir).c_str(), DIR_OPEN_MODE);
+  }
+  std::wstring wlocaleDir = aria2::utf8ToWChar(localeDir);
+  auto eh = aria2::make_unique<google_breakpad::ExceptionHandler>(wlocaleDir.c_str(),
+    nullptr,
+    callback,
+    nullptr, -1);
+  return eh;
+}
+#elif defined(__APPLE__)
+static bool callback(const char* dump_dir,
+  const char* minidump_id,
+  void* context,
+  bool succeeded) {
+  std::cerr << "Crash dump:" << dump_dir << "/" << minidump_id << std::endl;
+    return succeeded;
+}
+static std::unique_ptr<google_breakpad::ExceptionHandler> initExceptionHandler() {
+  std::string localeDir = aria2::util::applyDir(aria2::util::getProgramLocation(), "dumps");
+  aria2::File dir(localeDir);
+  if (!dir.exists()) {
+    a2mkdir(localeDir.c_str(), DIR_OPEN_MODE);
+  }
+  auto eh = aria2::make_unique<google_breakpad::ExceptionHandler>(
+    localeDir.c_str(),
+    nullptr,
+    callback,
+    nullptr,
+    true,
+    nullptr);
+  return eh;
+}
+#endif // _WIN32
+
+#endif // ENABLE_BREAKPAD
+
 int main(int argc, char** argv)
 {
+#ifdef ENABLE_BREAKPAD
+  auto eh = initExceptionHandler();
+#endif // ENABLE_BREAKPAD
   aria2::error_code::Value r;
   aria2::global::initConsole(false);
   try {

--- a/src/main.cc
+++ b/src/main.cc
@@ -52,11 +52,13 @@
 #include "File.h"
 #include <iostream>
 
+#ifdef ENABLE_BREAKPAD
 #ifdef _WIN32
 #include <client/windows/handler/exception_handler.h>
 #elif defined(__APPLE__)
 #include <client/mac/handler/exception_handler.h>
 #endif // _WIN32
+#endif // ENABLE_BREAKPAD
 
 
 namespace aria2 {

--- a/src/protocol/piece/Piece.cc
+++ b/src/protocol/piece/Piece.cc
@@ -340,7 +340,11 @@ void Piece::updateWrCache(WrDiskCache* diskCache, unsigned char* data,
   }
   assert(wrCache_);
   assert(capacity >= len);
-  A2_LOG_DEBUG(fmt("updateWrCache entry=%p", wrCache_.get()));
+  A2_LOG_DEBUG(fmt("updateWrCache entry=%p, goff=%lld, len=%lld, capacity=%lld",
+    wrCache_.get(),
+    goff,
+    static_cast<int64_t>(len),
+    static_cast<int64_t>(capacity)));
   auto cell = new WrDiskCacheEntry::DataCell();
   cell->goff = goff;
   cell->data = data;

--- a/src/storage/AbstractDiskWriter.cc
+++ b/src/storage/AbstractDiskWriter.cc
@@ -269,7 +269,7 @@ ssize_t AbstractDiskWriter::writeDataInternal(const unsigned char* data,
     seek(offset);
     while ((size_t)writtenLength < len) {
 #ifdef _WIN32
-      DWORD nwrite;
+      DWORD nwrite = 0;
       if (WriteFile(fd_, data + writtenLength, len - writtenLength, &nwrite,
                     0)) {
         writtenLength += nwrite;
@@ -307,7 +307,7 @@ ssize_t AbstractDiskWriter::readDataInternal(unsigned char* data, size_t len,
   else {
     seek(offset);
 #ifdef _WIN32
-    DWORD nread;
+    DWORD nread = 0;
     if (ReadFile(fd_, data, len, &nread, 0)) {
       return nread;
     }

--- a/src/storage/AbstractSingleDiskAdaptor.cc
+++ b/src/storage/AbstractSingleDiskAdaptor.cc
@@ -97,9 +97,9 @@ ssize_t AbstractSingleDiskAdaptor::readDataDropCache(unsigned char* data,
 void AbstractSingleDiskAdaptor::writeCache(const WrDiskCacheEntry* entry)
 {
   for (auto& d : entry->getDataSet()) {
-    A2_LOG_DEBUG(fmt("Cache flush goff=%" PRId64 ", len=%lu", d->goff,
-                     static_cast<unsigned long>(d->len)));
-    writeData(d->data + d->offset, d->len, d->goff);
+    A2_LOG_DEBUG(fmt("Cache flush goff=%" PRId64 ", len=%lld", d->goff,
+                     static_cast<int64_t>(d->len)));
+    writeData(d->data + d->offset, static_cast<size_t>(d->len), d->goff);
   }
 }
 

--- a/src/storage/AbstractSingleDiskAdaptor.cc
+++ b/src/storage/AbstractSingleDiskAdaptor.cc
@@ -96,6 +96,7 @@ ssize_t AbstractSingleDiskAdaptor::readDataDropCache(unsigned char* data,
 
 void AbstractSingleDiskAdaptor::writeCache(const WrDiskCacheEntry* entry)
 {
+  A2_LOG_DEBUG(fmt("Cache flush entry=%p", entry));
   for (auto& d : entry->getDataSet()) {
     A2_LOG_DEBUG(fmt("Cache flush goff=%" PRId64 ", len=%lld", d->goff,
                      static_cast<int64_t>(d->len)));

--- a/src/storage/MultiDiskAdaptor.cc
+++ b/src/storage/MultiDiskAdaptor.cc
@@ -433,8 +433,8 @@ ssize_t MultiDiskAdaptor::readData(unsigned char* data, size_t len,
 void MultiDiskAdaptor::writeCache(const WrDiskCacheEntry* entry)
 {
   for (auto& d : entry->getDataSet()) {
-    A2_LOG_DEBUG(fmt("Cache flush goff=%" PRId64 ", len=%lu", d->goff,
-                     static_cast<unsigned long>(d->len)));
+    A2_LOG_DEBUG(fmt("Cache flush goff=%" PRId64 ", len=%lld", d->goff,
+                     static_cast<int64_t>(d->len)));
     writeData(d->data + d->offset, d->len, d->goff);
   }
 }

--- a/src/storage/WrDiskCache.cc
+++ b/src/storage/WrDiskCache.cc
@@ -61,7 +61,7 @@ bool WrDiskCache::add(WrDiskCacheEntry* ent)
                      ent,
                      static_cast<int64_t>(ent->getSize()),
                      ent->getLastUpdate(), total_));
-    total_ += ent->getSize();
+    total_ += static_cast<int64_t>(ent->getSize());
     ensureLimit();
     return true;
   }
@@ -86,7 +86,7 @@ bool WrDiskCache::remove(WrDiskCacheEntry* ent)
                      ent,
                      static_cast<int64_t>(ent->getSize()),
                      ent->getLastUpdate(), total_));
-    total_ -= ent->getSize();
+    total_ -= static_cast<int64_t>(ent->getSize());
     return true;
   }
   else {
@@ -141,7 +141,7 @@ void WrDiskCache::ensureLimit()
                      ent,
                      static_cast<int64_t>(ent->getSizeKey()),
                      ent->getLastUpdate(), total_));
-    total_ -= ent->getSize();
+    total_ -= static_cast<int64_t>(ent->getSize());
     ent->writeToDisk();
     set_.erase(i);
 

--- a/src/storage/WrDiskCache.cc
+++ b/src/storage/WrDiskCache.cc
@@ -57,10 +57,10 @@ bool WrDiskCache::add(WrDiskCacheEntry* ent)
   ent->setLastUpdate(++clock_);
   std::pair<EntrySet::iterator, bool> rv = set_.insert(ent);
   if (rv.second) {
-    A2_LOG_DEBUG(fmt("Add cache entry=%p, size=%" PRId64 ", clock=%" PRId64 ", total=%" PRId64,
-                     ent,
-                     static_cast<int64_t>(ent->getSize()),
-                     ent->getLastUpdate(), total_));
+    // A2_LOG_DEBUG(fmt("Add cache entry=%p, size=%" PRId64 ", clock=%" PRId64 ", total=%" PRId64,
+    //                  ent,
+    //                  static_cast<int64_t>(ent->getSize()),
+    //                  ent->getLastUpdate(), total_));
     total_ += static_cast<int64_t>(ent->getSize());
     ensureLimit();
     return true;

--- a/src/storage/WrDiskCache.cc
+++ b/src/storage/WrDiskCache.cc
@@ -47,8 +47,7 @@ WrDiskCache::WrDiskCache(size_t limit) : limit_(limit), total_(0), clock_(0) {}
 WrDiskCache::~WrDiskCache()
 {
   if (total_) {
-    A2_LOG_WARN(fmt("Write disk cache is not empty size=%lu",
-                    static_cast<unsigned long>(total_)));
+    A2_LOG_WARN(fmt("Write disk cache is not empty size=%" PRId64,total_));
   }
 }
 
@@ -58,16 +57,23 @@ bool WrDiskCache::add(WrDiskCacheEntry* ent)
   ent->setLastUpdate(++clock_);
   std::pair<EntrySet::iterator, bool> rv = set_.insert(ent);
   if (rv.second) {
+    A2_LOG_DEBUG(fmt("Add cache entry=%p, size=%" PRId64 ", clock=%" PRId64 ", total=%" PRId64,
+                     ent,
+                     static_cast<int64_t>(ent->getSize()),
+                     ent->getLastUpdate(), total_));
     total_ += ent->getSize();
     ensureLimit();
     return true;
   }
   else {
-    A2_LOG_WARN(fmt("Found duplicate cache entry a.{size=%lu,clock=%" PRId64
-                    "} b{size=%lu,clock=%" PRId64 "}",
-                    static_cast<unsigned long>((*rv.first)->getSize()),
+    A2_LOG_WARN(fmt("Found duplicate cache total=%" PRId64 "a.{entry=%p, size=%" PRId64 ",clock=%" PRId64
+                    "} b{entry=%p, size=%" PRId64 ",clock=%" PRId64 "}",
+                    total_,
+                    (*rv.first),
+                    static_cast<int64_t>((*rv.first)->getSize()),
                     (*rv.first)->getLastUpdate(),
-                    static_cast<unsigned long>(ent->getSize()),
+                    ent,
+                    static_cast<int64_t>(ent->getSize()),
                     ent->getLastUpdate()));
     return false;
   }
@@ -76,9 +82,10 @@ bool WrDiskCache::add(WrDiskCacheEntry* ent)
 bool WrDiskCache::remove(WrDiskCacheEntry* ent)
 {
   if (set_.erase(ent)) {
-    A2_LOG_DEBUG(fmt("Removed cache entry size=%lu, clock=%" PRId64,
-                     static_cast<unsigned long>(ent->getSize()),
-                     ent->getLastUpdate()));
+    A2_LOG_DEBUG(fmt("Removed cache entry=%p, size=%" PRId64 ", clock=%" PRId64 ", total=%" PRId64,
+                     ent,
+                     static_cast<int64_t>(ent->getSize()),
+                     ent->getLastUpdate(), total_));
     total_ -= ent->getSize();
     return true;
   }
@@ -87,21 +94,24 @@ bool WrDiskCache::remove(WrDiskCacheEntry* ent)
   }
 }
 
-bool WrDiskCache::update(WrDiskCacheEntry* ent, ssize_t delta)
+bool WrDiskCache::update(WrDiskCacheEntry* ent, int64_t delta)
 {
   if (!set_.erase(ent)) {
     return false;
   }
-  A2_LOG_DEBUG(fmt("Update cache entry size=%lu, delta=%ld, clock=%" PRId64,
-                   static_cast<unsigned long>(ent->getSize()),
-                   static_cast<long>(delta), ent->getLastUpdate()));
+  A2_LOG_DEBUG(fmt("Update cache entry=%p, size=%" PRId64 ", delta=%" PRId64 ", clock=%" PRId64 ", total=%" PRId64,
+                   ent,
+                   static_cast<int64_t>(ent->getSize()),
+                   delta,
+                   ent->getLastUpdate(),
+                   total_));
 
   ent->setSizeKey(ent->getSize());
   ent->setLastUpdate(++clock_);
   set_.insert(ent);
 
   if (delta < 0) {
-    assert(total_ >= static_cast<size_t>(-delta));
+    assert(total_ >= -delta);
   }
   total_ += delta;
   ensureLimit();
@@ -112,10 +122,25 @@ void WrDiskCache::ensureLimit()
 {
   while (total_ > limit_) {
     auto i = set_.begin();
+    // find the first non-empty entry
+    for (; i != set_.end(); ++i) {
+      if ((*i)->getSize() <= 0) {
+        A2_LOG_WARN(fmt("Found empty cache entry=%p, size=%" PRId64 ", clock=%" PRId64 ", total=%" PRId64,
+                        *i,
+                        static_cast<int64_t>((*i)->getSize()),
+                        (*i)->getLastUpdate(), total_));
+        continue;
+      }
+    }
+    if (i == set_.end()) {
+      A2_LOG_WARN(fmt("Cache is empty but total=%" PRId64 ", limit=%" PRId64, total_, limit_));
+      break;
+    }
     WrDiskCacheEntry* ent = *i;
-    A2_LOG_DEBUG(fmt("Force flush cache entry size=%lu, clock=%" PRId64,
-                     static_cast<unsigned long>(ent->getSizeKey()),
-                     ent->getLastUpdate()));
+    A2_LOG_DEBUG(fmt("Force flush cache entry=%p, size=%" PRId64 ", clock=%" PRId64 ", total=%" PRId64,
+                     ent,
+                     static_cast<int64_t>(ent->getSizeKey()),
+                     ent->getLastUpdate(), total_));
     total_ -= ent->getSize();
     ent->writeToDisk();
     set_.erase(i);

--- a/src/storage/WrDiskCache.h
+++ b/src/storage/WrDiskCache.h
@@ -58,7 +58,7 @@ public:
   // Updates the already added entry |ent|. The |delta| means how many
   // bytes is increased in this update. If the size is reduced, use
   // negative value.
-  bool update(WrDiskCacheEntry* ent, ssize_t delta);
+  bool update(WrDiskCacheEntry* ent, int64_t delta);
   // Evicts entries from storage so that total size of cache is kept
   // under the limit.
   void ensureLimit();

--- a/src/storage/WrDiskCache.h
+++ b/src/storage/WrDiskCache.h
@@ -62,14 +62,14 @@ public:
   // Evicts entries from storage so that total size of cache is kept
   // under the limit.
   void ensureLimit();
-  size_t getSize() const { return total_; }
+  int64_t getSize() const { return total_; }
 
 private:
   typedef std::set<WrDiskCacheEntry*, DerefLess<WrDiskCacheEntry*>> EntrySet;
   // Maximum number of bytes the storage can cache.
-  size_t limit_;
+  int64_t limit_;
   // Current number of bytes cached.
-  size_t total_;
+  int64_t total_;
   EntrySet set_;
   int64_t clock_;
 };

--- a/src/storage/WrDiskCacheEntry.cc
+++ b/src/storage/WrDiskCacheEntry.cc
@@ -67,8 +67,8 @@ WrDiskCacheEntry::~WrDiskCacheEntry()
 void WrDiskCacheEntry::deleteDataCells()
 {
 
-  A2_LOG_DEBUG(fmt("WrDiskCacheEntry deleteDataCells %p",
-                   this));
+  // A2_LOG_DEBUG(fmt("WrDiskCacheEntry deleteDataCells %p",
+  //                  this));
   for (auto& e : set_) {
     delete[] e->data;
     delete e;

--- a/src/storage/WrDiskCacheEntry.cc
+++ b/src/storage/WrDiskCacheEntry.cc
@@ -110,7 +110,7 @@ size_t WrDiskCacheEntry::append(int64_t goff, const unsigned char* data,
   }
   auto i = set_.end();
   --i;
-  if (static_cast<int64_t>((*i)->goff + (*i)->len) == goff) {
+  if ((*i)->goff + static_cast<int64_t>((*i)->len) == goff) {
     size_t wlen = std::min((*i)->capacity - (*i)->len, len);
     memcpy((*i)->data + (*i)->offset + (*i)->len, data, wlen);
     (*i)->len += wlen;

--- a/src/storage/WrDiskCacheEntry.cc
+++ b/src/storage/WrDiskCacheEntry.cc
@@ -66,6 +66,9 @@ WrDiskCacheEntry::~WrDiskCacheEntry()
 
 void WrDiskCacheEntry::deleteDataCells()
 {
+
+  A2_LOG_DEBUG(fmt("WrDiskCacheEntry deleteDataCells %p",
+                   this));
   for (auto& e : set_) {
     delete[] e->data;
     delete e;

--- a/src/stream/SinkStreamFilter.cc
+++ b/src/stream/SinkStreamFilter.cc
@@ -55,14 +55,14 @@ ssize_t SinkStreamFilter::transform(const std::shared_ptr<BinaryStream>& out,
                                     const std::shared_ptr<Segment>& segment,
                                     const unsigned char* inbuf, size_t inlen)
 {
-  size_t wlen;
+  int64_t wlen;
   if (inlen > 0) {
     if (segment->getLength() > 0) {
       // We must not write data larger than available space in
       // segment.
       assert(segment->getLength() >= segment->getWrittenLength());
-      size_t lenAvail = segment->getLength() - segment->getWrittenLength();
-      wlen = std::min(inlen, lenAvail);
+      int64_t lenAvail = segment->getLength() - segment->getWrittenLength();
+      wlen = std::min(static_cast<int64_t>(inlen), lenAvail);
     }
     else {
       wlen = inlen;

--- a/src/util/util.cc
+++ b/src/util/util.cc
@@ -647,7 +647,8 @@ SegList<int> parseIntSegments(const std::string& src)
       throw DL_ABORT_EX(fmt(MSG_INCOMPLETE_RANGE, std::string(i, j).c_str()));
     }
     else {
-      int a, b;
+      int a = 0;
+      int b = 0;
       if (parseIntNoThrow(a, std::string(i, p)) &&
           parseIntNoThrow(b, (std::string(p + 1, j)))) {
         sgl.add(a, b + 1);
@@ -1904,7 +1905,12 @@ void usleep(long microseconds)
   ::usleep(microseconds);
 #elif defined(HAVE_WINSOCK2_H)
 
-  LARGE_INTEGER current, freq, end;
+  LARGE_INTEGER current;
+  LARGE_INTEGER freq;
+  LARGE_INTEGER end;
+  current.QuadPart = 0;
+  freq.QuadPart = 0;
+  end.QuadPart = 0;
 
   static enum {
     GET_FREQUENCY,

--- a/xmake.lua
+++ b/xmake.lua
@@ -20,6 +20,12 @@ option("use_quictls")
     set_description("Use external use_quictls library")
 option_end()
 
+option("with_breakpad")
+    set_default(false)
+    set_showmenu(true)
+    set_description("Use external with_breakpad library")
+option_end()
+
 option("unit")
     set_default(false)
     set_showmenu(true)
@@ -224,6 +230,10 @@ local sourceDirs = {
 target("aria2")
     set_kind("$(kind)")
     add_files("deps/wslay/lib/*.c")
+    if is_mode("release") and get_config("with_breakpad") then
+        add_cxxflags("/Zi", "/FS", "/Fd$(buildir)\\$(plat)\\$(arch)\\release\\aria2.pdb")
+        add_ldflags("/DEBUG", "/PDB:$(buildir)\\$(plat)\\$(arch)\\release\\aria2c.pdb")
+    end
     for _, dir in ipairs(sourceDirs) do
         add_files(dir .. "/*.cc")
         add_includedirs(dir)
@@ -360,6 +370,14 @@ rule("mo")
 rule_end()
 
 target("aria2c")
+    if is_mode("release") and get_config("with_breakpad") then
+        add_cxxflags("-Zi", "-FS", "-Fd$(buildir)\\$(plat)\\$(arch)\\release\\aria2.pdb")
+        add_ldflags("/DEBUG", "/PDB:$(buildir)\\$(plat)\\$(arch)\\release\\aria2c.pdb")
+    end
+    if get_config("with_breakpad") then
+        add_packages("breakpad")
+        add_defines("ENABLE_BREAKPAD=1")
+    end
     if is_plat("windows", "mingw") then
         add_packages("gettext-tools")
         add_files("src/resource.rc")
@@ -368,7 +386,7 @@ target("aria2c")
     add_files("po/*.po")
     add_files("src/*.cc")
     add_deps("aria2")
-    add_includedirs("include", "compat", "src/core", "src/tls", "src/network", "src/util")
+    add_includedirs("include", "compat", "src/core", "src/tls", "src/network", "src/util", "src/storage")
     add_defines("HAVE_CONFIG_H=1")
     if is_plat("mingw") then
         add_ldflags("-static")

--- a/xmake.lua
+++ b/xmake.lua
@@ -231,8 +231,12 @@ target("aria2")
     set_kind("$(kind)")
     add_files("deps/wslay/lib/*.c")
     if is_mode("release") and get_config("with_breakpad") then
-        add_cxxflags("/Zi", "/FS", "/Fd$(buildir)\\$(plat)\\$(arch)\\release\\aria2.pdb")
-        add_ldflags("/DEBUG", "/PDB:$(buildir)\\$(plat)\\$(arch)\\release\\aria2c.pdb")
+        if is_plat("windows") then
+            add_cxflags("/Zi", "/FS", "/Fd$(buildir)\\$(plat)\\$(arch)\\release\\aria2.pdb")
+            add_ldflags("/DEBUG", "/PDB:$(buildir)\\$(plat)\\$(arch)\\release\\aria2.pdb")
+        else
+            add_cxflags("-g")
+        end
     end
     for _, dir in ipairs(sourceDirs) do
         add_files(dir .. "/*.cc")
@@ -371,8 +375,12 @@ rule_end()
 
 target("aria2c")
     if is_mode("release") and get_config("with_breakpad") then
-        add_cxxflags("-Zi", "-FS", "-Fd$(buildir)\\$(plat)\\$(arch)\\release\\aria2.pdb")
-        add_ldflags("/DEBUG", "/PDB:$(buildir)\\$(plat)\\$(arch)\\release\\aria2c.pdb")
+        if is_plat("windows") then
+            add_cxflags("/Zi", "/FS", "/Fd$(buildir)\\$(plat)\\$(arch)\\release\\aria2c.pdb")
+            add_ldflags("/DEBUG", "/PDB:$(buildir)\\$(plat)\\$(arch)\\release\\aria2c.pdb")
+        else
+            add_cxflags("-g")
+        end
     end
     if get_config("with_breakpad") then
         add_packages("breakpad")


### PR DESCRIPTION
- `AutoSaveCommand` 虽然改造为异步了，但是 `ControlFile` 并非有锁保护，导致完成任务和自动保存同时访问时会导致崩溃
- 添加了 `breakpad` 支持，可以在崩溃时捕捉栈